### PR TITLE
feat: update to current ferm, fix regexp and improve highlighting

### DIFF
--- a/syntax/ferm.vim
+++ b/syntax/ferm.vim
@@ -64,8 +64,8 @@ endif
 "============================================================================
 
 syntax keyword fermMatch protocol proto fragment syn
-syntax keyword fermMatchSrc interface saddr sport
-syntax keyword fermMatchDst outerface daddr dport
+syntax keyword fermMatchSrc interface saddr sport sports
+syntax keyword fermMatchDst outerface daddr dport dports
 
 syntax match fermMatchModule contains=fermModuleName "mod\(ule\)\?\s\+\w\+"
 


### PR DESCRIPTION
Sorry for such a massive PR, but there was many enough things to update:

- chore: linter (vint) warnings
- fix: invalid regexp (`[eth|ppp]` and `$[_A-Za-z0-9]+` doesn't mean what it should mean)
- fix: invalid syntax priority (order of some lines)
- fix: missing `@` from `iskeyword` (needed for `@def` etc.)
- fix: disable spellchecker outside of comments
- feat: changes in current ferm version (new/changed keywords)
- feat: changes in current linux kernel version (new/changed keywords)

When I've realized I just can't make this PR small and focused enough I give up and decide to include several improvements too:

- fix: more reasonable default linking to highlight groups
- feat: add `fermMatchSrc` and `fermMatchDst` to make it possible to distinguish between `sport` and `dport` things by color (not in default `hi link`, but user may configure this now and it turns out to be really useful feature to me)
- feat: improve detection of "contained" things (jump target, module names, variables inside strings, interface groups like `'eth+'`)
- feat: add highlight for plain numbers and IP addresses/networks (only v4 so far)

P.S. I didn't get how mentioned custom variables are used (`g:Ferm_SpecialDelimiters` etc.) - I suppose they are just unused leftovers from some old versions and should be removed too…?

Here is how example config looks like with my colorscheme:
![изображение](https://user-images.githubusercontent.com/1354301/75102424-d9571c00-55f3-11ea-9995-a484c1f3a88d.png)
