### PR TITLE
Add "ip6" to fermModuleType for consistent "domain (ip ip6)" highlighting

### DIFF
--- a/syntax/ferm.vim
+++ b/syntax/ferm.vim
@@ -104,7 +104,7 @@ syntax keyword fermModuleType
     \ INVALID NEW ESTABLISHED RELATED UNTRACKED
     \ NONE EXPECTED SEEN_REPLY ASSURED CONFIRMED
     \ SYN ACK FIN RST URG PSH ALL
-    \ ip icmp tcp udp ipv6 gre esp ah ipv6-icmp
+    \ ip ip6 icmp tcp udp ipv6 gre esp ah ipv6-icmp
 
 " From --reject-with option
 syntax keyword fermModuleType


### PR DESCRIPTION
It was bugging me that the `ip` in `domain (ip ip6)` was highlighted, but the `ip6` wasn't:

![image](https://user-images.githubusercontent.com/6863569/117185941-a8b76880-adda-11eb-8ed0-f1d31822e91a.png)

I've added it to the `fermModuleType` group which seems to be the right one because it already contains `ip`? I'm not too sure, maybe the domain arguments needs to have their own group with only `ip` and `ip6` in it?